### PR TITLE
Fixes wrong category issue

### DIFF
--- a/pretix_attestation_plugin/__init__.py
+++ b/pretix_attestation_plugin/__init__.py
@@ -18,7 +18,7 @@ class PluginApp(PluginConfig):
         description = gettext_lazy('Pretix Ethereum Plugin Developers')
         visible = True
         version = __version__
-        category = 'PAYMENT'
+        category = 'Other'
         compatibility = "pretix>=3.8.0"
 
     def ready(self):


### PR DESCRIPTION
Now attestation plugin is under "Other". Related to #9 

<img width="1142" alt="Screen Shot 2021-01-22 at 22 59 16" src="https://user-images.githubusercontent.com/39133100/105528294-9ff8c600-5d06-11eb-923e-42cb888540a9.png">
