### PR TITLE
path to the jar file needs to be computed

### DIFF
--- a/pretix_attestation_plugin/email.py
+++ b/pretix_attestation_plugin/email.py
@@ -6,6 +6,11 @@ from .models import (
     BaseURL,
 )
 
+"""
+We need to register two email placeholders under the same name,
+the proper one is picked based on the different context.
+"""
+
 
 class OrderAttestationPlaceholder(BaseMailTextPlaceholder):
     def __init__(self):

--- a/pretix_attestation_plugin/generator/java_generator_wrapper.py
+++ b/pretix_attestation_plugin/generator/java_generator_wrapper.py
@@ -1,26 +1,30 @@
+from os import path
+from subprocess import Popen, PIPE
+
 from pretix.base.models import OrderPosition
 
-# Here key indicates .pem file in RFC 5915 format. Before using this generator, key needs
-# to be uploaded through form.
-# Currently, uploaded keys are stored in KEYFILE_DIR variable specified in views.py. Now
-# the directory is "pretix_attestation_plugin/static/pretix_attestation_plugin/keyfiles"
+"""
+A key indicates .pem file in RFC 5915 format.
 
+Before using this generator, key needs to be uploaded through form.
+`Attestation Plugin Settings` can be used for that.
+"""
 
 def generate_link(order_position: OrderPosition,
                   path_to_key: str,
-                  path_to_generator: str = 'pretix_attestation_plugin/generator/attestation-all.jar',
+                  generator_jar: str = 'attestation-all.jar',
                   ticket_staus: str = '1') -> str:
-    from subprocess import (
-        Popen,
-        PIPE
-    )
 
-    import os.path
-
-    if not os.path.isfile(path_to_key):
+    if not path.isfile(path_to_key):
         raise ValueError(f'Key file not found in {path_to_key}')
 
-    if not os.path.isfile(path_to_generator):
+    # either generator_jar is the full path to the java file or it sits next to the python file
+    if path.isfile(generator_jar):
+        path_to_generator = path.abspath(generator_jar)
+    else:
+        this_module_path = path.dirname(path.abspath(__file__))
+        path_to_generator = path.join(this_module_path, generator_jar)
+    if not path.isfile(path_to_generator):
         raise ValueError(f'Generator file not found in {path_to_generator}')
 
     email = order_position.attendee_email

--- a/pretix_attestation_plugin/generator/java_generator_wrapper.py
+++ b/pretix_attestation_plugin/generator/java_generator_wrapper.py
@@ -10,6 +10,7 @@ Before using this generator, key needs to be uploaded through form.
 `Attestation Plugin Settings` can be used for that.
 """
 
+
 def generate_link(order_position: OrderPosition,
                   path_to_key: str,
                   generator_jar: str = 'attestation-all.jar',

--- a/pretix_attestation_plugin/generator/java_generator_wrapper.py
+++ b/pretix_attestation_plugin/generator/java_generator_wrapper.py
@@ -26,7 +26,7 @@ def generate_link(order_position: OrderPosition,
         this_module_path = path.dirname(path.abspath(__file__))
         path_to_generator = path.join(this_module_path, generator_jar)
     if not path.isfile(path_to_generator):
-        raise ValueError(f'Generator file not found in {path_to_generator}')
+        raise ValueError(f'Generator file not found in {generator_jar}')
 
     email = order_position.attendee_email
     event_id = str(order_position.order.event.id)

--- a/tests/link/test_java_link_generator.py
+++ b/tests/link/test_java_link_generator.py
@@ -36,5 +36,5 @@ def test_invalid_path_to_generator(order_position):
         generate_link(
             order_position=order_position,
             path_to_key='tests/key.pem',
-            path_to_generator=invalid_path
+            generator_jar=invalid_path
         )


### PR DESCRIPTION
The `generator` function needs a full path to the `JAR` file, which can be much different when this library is installed somewhere in the `site-packages`.